### PR TITLE
FEAT: 메인로직 구체화, 관련된 ClientMetaData, Data 수정

### DIFF
--- a/include/ClientMetaData.hpp
+++ b/include/ClientMetaData.hpp
@@ -39,7 +39,8 @@ class ClientMetaData {
 
     // kevent에서 listen fd가 read 했을 때, accept할 때, listen_fd저장, port번호
     // 저장
-    void AddData(const fd& listen_fd, const fd& client_fd, const fd& port);
+    void AddData(const fd& listen_fd, const fd& client_fd, const fd& host_port, \
+                  char* client_name, char* client_port);
     void SetEvent(struct kevent* event);
     void SetEventByFd(struct kevent* event, int fd);
     void SetConfig();
@@ -60,8 +61,8 @@ class ClientMetaData {
     void SetEntity(char* entitiy);
 
     // data 통채로 원할 때
-    Data& GetData();
-    Data& GetDataByFd(int fd);
+    Data* GetData();
+    Data* GetDataByFd(int fd);
 
     // core에서 요청 헤더 데이터 필요할 때
     struct HTTPMessage* GetReqHeader();

--- a/include/Data.hpp
+++ b/include/Data.hpp
@@ -34,6 +34,7 @@ class Data {
   void SetStatusCode(int status_code);
   bool IsTimeout() const;
   int GetFileFd() const;
+  int GetLogFileFd() const;
   int GetPipeWrite() const;
   int GetPipeRead() const;
 
@@ -71,13 +72,16 @@ class Data {
 
  public:
   int litsen_fd_;  // 어느 listen fd에 연결됐는지
-  int port_;  // listen fd에 bind 되어있는 port 번호. config볼 때 필요
+  int host_port_;  // listen fd에 bind 되어있는 port 번호. config볼 때 필요
   int client_fd_;
-  // TODO: client ip, port, request time도 저장해주면 좋을듯(로그 남기기 위해서)
+  std::string host;
+  char* client_name_;
+  char* client_port_;
   int status_code_;  // 상태코드 enum 정의 필요
   bool timeout_;
   bool cgi;
   int file_fd_;
+  int log_file_fd_;
   int pipe_[2];
   struct kevent* event_;  // fd(ident), flag들
   const ServerConfigInfo* config_;

--- a/include/MsgComposer.hpp
+++ b/include/MsgComposer.hpp
@@ -7,8 +7,10 @@
 
 class MsgComposer {
  public:
-  MsgComposer(Data* client);
+  MsgComposer();
+  // MsgComposer(Data* client);
   ~MsgComposer(void);
+  void SetData(Data* client);
   void InitResMsg(void);
   const char* GetResponse(void);
   std::size_t getLength(void) const;

--- a/include/ResHandler.hpp
+++ b/include/ResHandler.hpp
@@ -9,8 +9,9 @@
 
 class ResHandler {
  public:
-  ResHandler(const char* response, std::size_t response_length);
+  ResHandler(void);
   ~ResHandler(void);
+  void SetResponse(const char* response, std::size_t response_length);
   void SendToClient(int client_fd);
 
  private:

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -1,11 +1,12 @@
 #ifndef SERVER_HPP
 #define SERVER_HPP
 
-#include "MethodProcessor.hpp"
 #include "ServerConfigInfo.hpp"
 #include "ClientMetaData.hpp"
 #include "ReqHandler.hpp"
-// #include "WebServ.hpp"
+#include "MethodProcessor.hpp"
+#include "MsgComposer.hpp"
+#include "ResHandler.hpp"
 
 #include <arpa/inet.h> /* htons, htonl, ntohs, ntohl */
 #include <fcntl.h>     /* fcntl */
@@ -31,16 +32,16 @@
 #define DISABLE 0
 #define ENABLE 1
 
-#define LISTEN_FD 255
-#define CLIENT_FD 256
-#define FILE_FD 257
-#define PIPE_FD 258
+// #define LISTEN_FD 255
+// #define CLIENT_FD 256
+// #define FILE_FD 257
+// #define PIPE_FD 258
 
 
-typedef struct s_fd_info {
-	int which_fd;
-	Data *parent;
-} t_fd_info;
+// typedef struct s_fd_info {
+// 	int which_fd;
+// 	Data *parent;
+// } t_fd_info;
 
 
 typedef struct s_litening {
@@ -48,8 +49,6 @@ typedef struct s_litening {
   int port;
   int fd;
 } t_listening;
-
-class MethodProcessor;
 
 class Server {
  public:
@@ -66,13 +65,17 @@ class Server {
 	// server_info를 Method_Processor 호출할 때, 필요하기 때문에
 	// Class 내부에 저장함.
 	std::vector<ServerConfigInfo> server_infos_;
-	MethodProcessor mp_;
 
  private:
   int kq_;
   struct kevent events_[MAXLISTEN + BACKLOG];
   std::set<t_listening*> servers_;
-  ClientMetaData clients_;
+  ClientMetaData* clients_;
+	MethodProcessor* mp_;
+  ReqHandler* req_handler_;
+  ResHandler* res_handler_;
+  MethodProcessor* method_processor_;
+  MsgComposer* msg_composer_;
 
   void Act(void);
   void AcceptNewClient(int idx);

--- a/src/MetaData/ClientMetaData.cpp
+++ b/src/MetaData/ClientMetaData.cpp
@@ -22,7 +22,7 @@ void ClientMetaData::ValidCheckToAccessDataByFd(int fd) {
 
 void ClientMetaData::InitializeData(Data* data) {
   data->litsen_fd_ = -1;
-  data->port_ = -1;
+  data->host_port_ = -1;
   // data->client_fd_ = -1;
   data->event_ = NULL;
   // data->config_ = NULL;
@@ -36,13 +36,15 @@ void ClientMetaData::SetCurrentFd(const fd& client_fd) {
 }
 
 void ClientMetaData::AddData(const int& listen_fd, const int& client_fd,
-                             const int& port) {
+                             const int& host_port, char* client_name, char* client_port) {
   Data new_data;
 
   InitializeData(&new_data);
   new_data.litsen_fd_ = listen_fd;
   new_data.client_fd_ = client_fd;
-  new_data.port_ = port;
+  new_data.host_port_ = host_port;
+  new_data.client_name_ = strdup(client_name);
+  new_data.client_port_ = strdup(client_port);
   datas_.insert(std::pair<int, Data>(client_fd, new_data));
   current_fd_ = client_fd;
 }
@@ -99,14 +101,14 @@ void ClientMetaData::SetResEntity(t_entity* res_enetity)
   datas_[current_fd_].res_entity_ = res_enetity;
 }
 
-Data& ClientMetaData::GetData() {
+Data* ClientMetaData::GetData() {
   ValidCheckToAccessData();
-  return datas_[current_fd_];
+  return &datas_[current_fd_];
 }
 
-Data& ClientMetaData::GetDataByFd(int fd) {
+Data* ClientMetaData::GetDataByFd(int fd) {
 	ValidCheckToAccessDataByFd(fd);
-	return datas_[fd];
+	return &datas_[fd];
 }
 
 t_req_msg* ClientMetaData::GetReqMsgByFd(int fd)
@@ -132,7 +134,7 @@ ServerConfigInfo* ClientMetaData::GetConfig() {
 
 int ClientMetaData::GetPort() {
   ValidCheckToAccessData();
-  return datas_[current_fd_].port_;
+  return datas_[current_fd_].host_port_;
 }
 
 int ClientMetaData::GetDataCount(void) {

--- a/src/MetaData/Data.cpp
+++ b/src/MetaData/Data.cpp
@@ -6,7 +6,7 @@
  */
 Data::Data()
     : litsen_fd_(-1),
-      port_(-1),
+      host_port_(-1),
       client_fd_(-1),
       timeout_(false),
       event_(NULL),
@@ -34,13 +34,14 @@ void Data::Clear() {
   }
   if (res_message_) cgi = false;
   file_fd_ = -1;
+  log_file_fd_ = -1;
   pipe_[READ] = -1;
   pipe_[WRITE] = -1;
 }
 
 int Data::GetListenFd() const { return litsen_fd_; }
 
-int Data::GetListenPort() const { return port_; }
+int Data::GetListenPort() const { return host_port_; }
 
 int Data::GetClientFd() const { return client_fd_; }
 
@@ -51,6 +52,8 @@ void Data::SetStatusCode(int status_code) { status_code_ = status_code; }
 bool Data::IsTimeout() const { return timeout_; }
 
 int Data::GetFileFd() const { return file_fd_; }
+
+int Data::GetLogFileFd() const {return log_file_fd_; }
 
 int Data::GetPipeWrite() const { return pipe_[WRITE]; }
 

--- a/src/MethodProcessor/MethodProcessor.cpp
+++ b/src/MethodProcessor/MethodProcessor.cpp
@@ -46,7 +46,7 @@ void MethodProcessor::ChangeEvents(unsigned long ident, short filter,
 
 void MethodProcessor::GETFirst(int curfd, ClientMetaData* clients,
                                struct kevent& cur_event) {
-  Data* client = &clients->GetDataByFd(curfd);
+  Data* client = clients->GetDataByFd(curfd);
   switch (client->e_stage) {
     case GET_HTML:
       GETSecond(curfd, clients, cur_event);
@@ -260,7 +260,7 @@ char* MethodProcessor::CopyCstr(const char* cstr, size_t length) {
 void MethodProcessor::GETSecondCgi(int curfd, ClientMetaData* clients,
                                    struct kevent& cur_event) {
   // TODO : CGI 읽기 구현
-  Data* client = &clients->GetData();
+  Data* client = clients->GetData();
   client->e_stage = GET_FINISHED;
   client->res_entity_->length_ = cur_event.data;
   client->res_entity_->data_ = new char[client->res_entity_->length_];
@@ -274,7 +274,7 @@ void MethodProcessor::GETSecondCgi(int curfd, ClientMetaData* clients,
 
 void MethodProcessor::GETSecondFile(int curfd, ClientMetaData* clients,
                                     struct kevent& cur_event) {
-  Data* client = &clients->GetData();
+  Data* client = clients->GetData();
   client->e_stage = GET_FINISHED;
   client->res_entity_->length_ = FileSize(client->GetReqURL().c_str());
 
@@ -290,7 +290,7 @@ void MethodProcessor::GETSecondFile(int curfd, ClientMetaData* clients,
 
 void MethodProcessor::GETSecond(int curfd, ClientMetaData* clients,
                                 struct kevent& cur_event) {
-  Data* client = &clients->GetDataByFd(curfd);
+  Data* client = clients->GetDataByFd(curfd);
   client->e_stage = GET_FINISHED;
   client->res_entity_->length_ = FileSize(client->GetReqURL().c_str());
 

--- a/src/MethodProcessor/MethodProcessor.cpp
+++ b/src/MethodProcessor/MethodProcessor.cpp
@@ -130,12 +130,12 @@ void MethodProcessor::GETFirst(int curfd, ClientMetaData* clients,
         /*handling index.html*/
         client->e_stage = GET_HTML;
         /* cache data index.html */
-        if (cache_entity_.find(client->port_) != cache_entity_.end()) {
+        if (cache_entity_.find(client->host_port_) != cache_entity_.end()) {
           client->res_entity_->type_ = strdup(TYPE_HTML);
           client->res_entity_->data_ = strdup(
-              cache_entity_.find(client->port_).operator*().second->data_);
+              cache_entity_.find(client->host_port_).operator*().second->data_);
           client->res_entity_->length_ =
-              cache_entity_.find(client->port_).operator*().second->length_;
+              cache_entity_.find(client->host_port_).operator*().second->length_;
           client->e_stage = GET_FINISHED;
 
           ChangeEvents(client->event_->ident, EVFILT_WRITE, EV_ENABLE, 0, 0,

--- a/src/MsgComposer/MsgComposer.cpp
+++ b/src/MsgComposer/MsgComposer.cpp
@@ -1,6 +1,6 @@
 #include "../../include/MsgComposer.hpp"
 
-MsgComposer::MsgComposer(Data* client) : client_(client) {
+MsgComposer::MsgComposer() : client_(NULL) {
   Clear();
   status_infos_.insert(std::make_pair(100, "Continue"));
   status_infos_.insert(std::make_pair(101, "Switching Protocols"));
@@ -44,6 +44,50 @@ MsgComposer::MsgComposer(Data* client) : client_(client) {
   status_infos_.insert(std::make_pair(505, "HTTP Version Not Supported"));
 }
 
+// MsgComposer::MsgComposer(Data* client) : client_(client) {
+//   Clear();
+//   status_infos_.insert(std::make_pair(100, "Continue"));
+//   status_infos_.insert(std::make_pair(101, "Switching Protocols"));
+//   status_infos_.insert(std::make_pair(200, "OK"));
+//   status_infos_.insert(std::make_pair(201, "Created"));
+//   status_infos_.insert(std::make_pair(202, "Accepted"));
+//   status_infos_.insert(std::make_pair(203, "Non-Authoritative Information"));
+//   status_infos_.insert(std::make_pair(204, "No Content"));
+//   status_infos_.insert(std::make_pair(205, "Content"));
+//   status_infos_.insert(std::make_pair(206, "Partial Content"));
+//   status_infos_.insert(std::make_pair(300, "Multiple Choices"));
+//   status_infos_.insert(std::make_pair(301, "Moved Permanently"));
+//   status_infos_.insert(std::make_pair(302, "Found"));
+//   status_infos_.insert(std::make_pair(303, "See Other"));
+//   status_infos_.insert(std::make_pair(304, "Not Modified"));
+//   status_infos_.insert(std::make_pair(305, "Use Proxy"));
+//   status_infos_.insert(std::make_pair(307, "Temporary Redirect"));
+//   status_infos_.insert(std::make_pair(400, "Bad Request"));
+//   status_infos_.insert(std::make_pair(401, "Unauthorized"));
+//   status_infos_.insert(std::make_pair(402, "Payment Required"));
+//   status_infos_.insert(std::make_pair(403, "Payment Required"));
+//   status_infos_.insert(std::make_pair(404, "Not Found"));
+//   status_infos_.insert(std::make_pair(405, "Method Not Allowed"));
+//   status_infos_.insert(std::make_pair(406, "Not Acceptable"));
+//   status_infos_.insert(std::make_pair(407, "Proxy Authentication Required"));
+//   status_infos_.insert(std::make_pair(408, "Request Timeout"));
+//   status_infos_.insert(std::make_pair(409, "Conflict"));
+//   status_infos_.insert(std::make_pair(410, "Gone"));
+//   status_infos_.insert(std::make_pair(411, "Length Required"));
+//   status_infos_.insert(std::make_pair(412, "Precondition Failed"));
+//   status_infos_.insert(std::make_pair(413, "Request Entity Too Large"));
+//   status_infos_.insert(std::make_pair(414, "Request-URI Too Long"));
+//   status_infos_.insert(std::make_pair(415, "Unsupported Media Type"));
+//   status_infos_.insert(std::make_pair(416, "Requested Range Not Satisfiable"));
+//   status_infos_.insert(std::make_pair(417, "Expectation Failed"));
+//   status_infos_.insert(std::make_pair(500, "Internal Server Error"));
+//   status_infos_.insert(std::make_pair(501, "Not Implemented"));
+//   status_infos_.insert(std::make_pair(502, "Bad Gateway"));
+//   status_infos_.insert(std::make_pair(503, "Service Unavailable"));
+//   status_infos_.insert(std::make_pair(504, "Gateway Timeout"));
+//   status_infos_.insert(std::make_pair(505, "HTTP Version Not Supported"));
+// }
+
 MsgComposer::~MsgComposer(void) {}
 
 void MsgComposer::SetStatusText(void) {
@@ -53,6 +97,10 @@ void MsgComposer::SetStatusText(void) {
   } else {
     res_msg_.status_text_ = "Unknown Status Code Error";
   }
+}
+
+void MsgComposer::SetData(Data* client) {
+  client_ = client;
 }
 
 void MsgComposer::SetHeaders(void) {

--- a/src/ResHandler/ResHandler.cpp
+++ b/src/ResHandler/ResHandler.cpp
@@ -1,9 +1,18 @@
 #include "../../include/ResHandler.hpp"
 
-ResHandler::ResHandler(const char* response, std::size_t response_length)
-    : response_(response), response_length_(response_length) {}
+ResHandler::ResHandler()
+    : response_(NULL), response_length_(0) {}
 
-ResHandler::~ResHandler(void) {}
+ResHandler::~ResHandler(void) {
+  if (response_ != NULL) {
+    delete response_;
+  }
+}
+
+void ResHandler::SetResponse(const char* response, std::size_t response_length) {
+  response_ = response;
+  response_length_ = response_length;
+}
 
 void ResHandler::SendToClient(int client_fd) {
   #if RES_HANDLER

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -4,10 +4,22 @@
 #include <netdb.h>
 
 // Server::Server() : kq_(kqueue()) {}
-Server::Server(std::vector<ServerConfigInfo> server_info) : server_infos_(server_info), mp_(server_info), kq_(kqueue()) {}
+Server::Server(std::vector<ServerConfigInfo> server_info) 
+: server_infos_(server_info), kq_(kqueue()) {
+  mp_ = new MethodProcessor(server_info);
+  clients_ = new ClientMetaData;
+  req_handler_ = new ReqHandler;
+  res_handler_ = new ResHandler;
+  msg_composer_ = new MsgComposer;
+}
+
 Server::~Server(void) {
   close(kq_);
   servers_.clear();
+  delete clients_;
+  delete req_handler_;
+  delete res_handler_;
+  delete msg_composer_;
 }
 
 void Server::Run(void) {
@@ -19,10 +31,26 @@ void Server::Run(void) {
   }
 }
 
-// void Server::Init(const std::vector<ServerConfigInfo>& server_infos) {
 void Server::Init(void) {
   for (size_t i = 0; i < server_infos_.size(); ++i) {
-    SetHostPortAvaiable(server_infos_[i].host_, server_infos_[i].port_);
+    #if SERVER
+      if (servers_.size() == MAXLISTEN) {
+        std::cerr << "Error: full of listening\n";
+        return;
+      }
+    #endif
+      struct kevent event;
+      int listenfd;
+
+      BindListen(server_infos_[i].host_, server_infos_[i].port_, listenfd);
+      EV_SET(&event, listenfd, EVFILT_READ, EV_ADD, 0, 0, (void *)&server_infos_[i]);
+      if (kevent(kq_, &event, 1, NULL, 0, NULL) == -1) {
+        throw std::runtime_error("Error: kevent()");
+      }
+      servers_.insert(CreateListening(server_infos_[i].host_, server_infos_[i].port_, listenfd));
+    #if SERVER
+      std::cout << server_infos_[i].host_ << " is listening port on " << server_infos_[i].port_ << "\n";
+    #endif
   }
 }
  // 임의로 public에 나둠 나중에 setter구현해야함
@@ -34,24 +62,68 @@ void Server::Act(void) {
     throw std::runtime_error("Error: kevent()");
   }
   for (int idx = 0; idx < n; ++idx) {
-		int which_fd = reinterpret_cast<t_fd_info *>(events_[idx].udata)->which_fd;
-		int16_t filter = events_[idx].filter;
-
-    if (which_fd == LISTEN_FD) {
+    /* listen port로 새로운 connect 요청이 들어옴 */
+    if (IsListenFd(events_[idx].ident) && events_[idx].filter == EVFILT_READ) {
       AcceptNewClient(idx);
-    } else if (which_fd == CLIENT_FD && filter == EVFILT_READ) { 
-			ActCoreLogic(idx);
-    } else if (which_fd == CLIENT_FD && filter == EVFILT_WRITE) {
-			DisConnect(events_[idx].ident);
-		} else if (which_fd == CLIENT_FD && events_[idx].flags == EV_EOF) {
-			DisConnect(events_[idx].ident);
-		} else if (which_fd == CLIENT_FD && filter == EVFILT_TIMER) {
-			DisConnect(events_[idx].ident);
-		} else if ((which_fd == FILE_FD || which_fd == PIPE_FD) && EVFILT_READ) {
-			DisConnect(events_[idx].ident);
-		} else if ((which_fd == FILE_FD || which_fd == PIPE_FD) && EVFILT_WRITE) {
-			DisConnect(events_[idx].ident);
-		}
+      continue;
+    }
+    Data* client = reinterpret_cast<Data *>(events_[idx].udata);
+    int event_fd = events_[idx].ident;
+    if (events_[idx].filter == EVFILT_READ) {
+      /* accept 된 port로 request 요청메세지 들어옴 */
+      if (event_fd == client->GetClientFd()) {
+        #if SERVER
+          std::cout << "[Server] Client READ fd : " << client->GetClientFd() << std::endl;
+        #endif
+      }
+      /* 내부에서 읽으려고 Open()한 File에 대한 이벤트 */
+      else if (event_fd == client->GetFileFd()) {
+        #if SERVER
+          std::cout << "[Server] File READ fd : " << event_fd << " == " << client->GetFileFd() << std::endl;
+        #endif
+        // 
+      }
+      /* CGI에게 반환받는 pipe[READ]에 대한 이벤트 */
+      else if (event_fd == client->GetPipeRead()) {
+        #if SERVER
+          std::cout << "[Server] Pipe READ fd : " << event_fd << " == " << client->GetPipeRead() << std::endl;
+        #endif
+        // pipe 읽기
+      }
+    }
+    else if (events_[idx].filter == EVFILT_WRITE) {
+      /* response 보낼 때에 대한 이벤트 */
+      if (event_fd == client->GetClientFd()) {
+        #if SERVER
+          std::cout << "[Server] Client Write :" << client->GetClientFd() << std::endl;
+        #endif
+      }
+      /* POST, PUT file에 대한 write 발생시 */
+      else if (event_fd == client->GetFileFd()) {
+
+      }
+      /* CGI에게 보내줄 pipe[WRITE]에 대한 이벤트 */
+      else if (event_fd == client->GetPipeRead()) {
+
+      }
+      /* log file에 대한 write 발생시 */
+      else if (event_fd == client->GetLogFileFd())
+        ;
+    }
+    else if (events_[idx].flags == EV_EOF) {
+      /* socket이 닫혔을 때 */
+      if (event_fd == client->GetClientFd()) {
+
+      }
+      /* file, pipe 등이 예상치 못하게 닫혔을 경우도 있을지 나중에 보기 */
+      else {
+
+      }
+    }
+    /* timeout 발생시 */
+    else if (events_[idx].filter == EVFILT_TIMER) {
+
+    }
 	}
 }
 
@@ -61,41 +133,48 @@ void Server::AcceptNewClient(int idx) {
   struct sockaddr_storage client_addr;
   char host[MAXBUF];
   char port[MAXBUF];
-  struct kevent event;
+  struct kevent event[2];
 
   client_len = sizeof(client_addr);
-  connfd = accept(events_[idx].ident, reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
+  connfd = accept(events_[idx].ident, 
+          reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
   if (connfd == -1) {
     throw std::runtime_error("Error: accept()");
   }
 
-	t_fd_info udata;
-	udata.parent = NULL;
-	udata.which_fd = CLIENT_FD;
+  /* non-block 세팅 필요 */
 
-  EV_SET(&event, connfd, EVFILT_READ, EV_ADD, 0, 0, &udata);
-  if (kevent(kq_, &event, 1, NULL, 0, NULL) == -1) {
+  /* Data 만들기 */
+  getnameinfo(reinterpret_cast<struct sockaddr*>(&client_addr), client_len, 
+              host, MAXBUF, port, MAXBUF, 0);
+  clients_->AddData(events_[idx].ident, connfd,
+                (reinterpret_cast<ServerConfigInfo *>(events_[idx].udata))->port_,
+                host, port);
+  clients_->SetEvent(&events_[idx]);
+  clients_->SetConfig();
+  std::cout << "Connected to (" << host << ", " << port << "). socket : " << connfd << std::endl;
+
+  /* event setting */
+  EV_SET(&event[0], connfd, EVFILT_READ, EV_ADD, 0, 0, clients_->GetData());
+  EV_SET(&event[1], connfd, EVFILT_WRITE, EV_ADD | EV_DISABLE, 0, 0, clients_->GetData()); // 추가
+  if (kevent(kq_, event, 2, NULL, 0, NULL) == -1) {
     throw std::runtime_error("Error: kevent()");
   }
-
-  getnameinfo(reinterpret_cast<struct sockaddr*>(&client_addr), client_len, host, MAXBUF, port, MAXBUF, 0);
-  clients_.AddData(events_[idx].ident, connfd, atoi(port));
-  std::cout << "Connected to (" << host << ", " << port << "). socket : " << connfd << std::endl;
 }
 
-void Server::ActCoreLogic(int idx) {
-  ReqHandler rq;
-	rq.SetClient(&clients_.GetDataByFd(events_[idx].ident));
-	rq.SetReadLen(events_[idx].data);
-	rq.RecvFromSocket();
-	rq.ParseRecv();
+// void Server::ActCoreLogic(int idx) {
+//   ReqHandler rq;
+// 	rq.SetClient(&clients_.GetDataByFd(events_[idx].ident));
+// 	rq.SetReadLen(events_[idx].data);
+// 	rq.RecvFromSocket();
+// 	rq.ParseRecv();
 
-	clients_.SetReqMessageByFd(rq.req_msg_, events_[idx].ident);
-	std::cout << rq.req_msg_->method_ << " " << rq.req_msg_->req_url_ << "\n";
-	std::map<std::string, std::string>::iterator it = rq.req_msg_->headers_.begin();
-	for(; it != rq.req_msg_->headers_.end(); ++it) {
-		std::cout << it->first << ": " << it->second << "\n";
-	}
+// 	clients_.SetReqMessageByFd(rq.req_msg_, events_[idx].ident);
+// 	std::cout << rq.req_msg_->method_ << " " << rq.req_msg_->req_url_ << "\n";
+// 	std::map<std::string, std::string>::iterator it = rq.req_msg_->headers_.begin();
+// 	for(; it != rq.req_msg_->headers_.end(); ++it) {
+// 		std::cout << it->first << ": " << it->second << "\n";
+// 	}
 
 	// clients_.GetDataByFd(events_[idx].ident).e_stage = GET_HTML;
 	// mp_.GETFirst(events_[idx].ident, &clients_, events_[idx]);
@@ -106,33 +185,34 @@ void Server::ActCoreLogic(int idx) {
 
   // TODO: call ReqHandler and run other process
   // TODO: call ResHandler and send data to client
-  DisConnect(events_[idx].ident);
-}
+//   DisConnect(events_[idx].ident);
+// }
 
-void Server::SetHostPortAvaiable(const std::string& host, const int& port) {
-#if SERVER
-  if (servers_.size() == MAXLISTEN) {
-    std::cerr << "Error: full of listening\n";
-    return;
-  }
-#endif
-  struct kevent event;
-  int listenfd;
+/* Init에 포함시켰음 */
+// void Server::SetHostPortAvaiable(const std::string& host, const int& port) {
+// #if SERVER
+//   if (servers_.size() == MAXLISTEN) {
+//     std::cerr << "Error: full of listening\n";
+//     return;
+//   }
+// #endif
+//   struct kevent event;
+//   int listenfd;
 
-  BindListen(host, port, listenfd);
+//   BindListen(host, port, listenfd);
 
-	t_fd_info udata;
-	udata.parent = NULL;
-	udata.which_fd = LISTEN_FD;
-  EV_SET(&event, listenfd, EVFILT_READ, EV_ADD, 0, 0, &udata);
-  if (kevent(kq_, &event, 1, NULL, 0, NULL) == -1) {
-    throw std::runtime_error("Error: kevent()");
-  }
-  servers_.insert(CreateListening(host, port, listenfd));
-#if SERVER
-  std::cout << host << " is listening port on " << port << "\n";
-#endif
-}
+// 	t_fd_info udata;
+// 	udata.parent = NULL;
+// 	udata.which_fd = LISTEN_FD;
+//   EV_SET(&event, listenfd, EVFILT_READ, EV_ADD, 0, 0, &udata);
+//   if (kevent(kq_, &event, 1, NULL, 0, NULL) == -1) {
+//     throw std::runtime_error("Error: kevent()");
+//   }
+//   servers_.insert(CreateListening(host, port, listenfd));
+// #if SERVER
+//   std::cout << host << " is listening port on " << port << "\n";
+// #endif
+// }
 
 void Server::BindListen(const std::string& host, const int& port, int& listenfd) {
   struct addrinfo* listp;
@@ -198,6 +278,5 @@ bool Server::IsListenFd(const int& fd) {
 }
 
 void Server::DisConnect(const int& fd) {
-  clients_.DeleteByFd(fd);
-  close(fd);
+  clients_->DeleteByFd(fd);
 }


### PR DESCRIPTION
1. kevent->udata 에 listen event에는 config* 저장, 나머지에는 Data* 저장
2. 모든 객체들을 server의 멤버변수로 포인터 형으로 선언. construct에서 new, distruct에서 delete. server에서 각 객체별로 처음 사용 때 Setter 호출 해야함

