### PR TITLE
122 CGIManeger push body data to cgi pipe

### DIFF
--- a/include/CGIManager.hpp
+++ b/include/CGIManager.hpp
@@ -9,6 +9,8 @@
 #include <sys/event.h>
 #include <sys/time.h>
 #include <cstdlib>
+#define READ 0
+#define WRITE 1
 
 
 class CGIManager {
@@ -16,6 +18,7 @@ class CGIManager {
         void SetData(Data* client);
         void SetCGIEnv(Data* client); // fork 안에서 해주기
         void SendToCGI(Data* client, int kq);
+        void WriteToCGIPipe(Data* client, int kq);
         void GetFromCGI(Data* client, int64_t len, int kq);
     private:
         Data* client_;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -76,6 +76,7 @@ class Server {
   void ExecuteReadEventFileFd(int idx);
   void ExecuteReadEventPipeFd(int idx);
   void ExecuteWriteEventFileFd(int idx);
+  void ExecuteWriteEventPipeFd(int idx);
   void ExecuteWriteEventClientFd(int idx); // Send()를 이거로 바꿈
 
   void Pong(int idx);

--- a/src/CGIManager/CGIMannager.cpp
+++ b/src/CGIManager/CGIMannager.cpp
@@ -71,11 +71,17 @@ void CGIManager::SendToCGI(Data* client, int kq)
     SetData(client);
     int p[2];
     pid_t pid;
-    pipe(p);
 
-    client_->SetPipeRead(p[READ]);
-    client_->SetPipeWrite(p[WRITE]);
-    pid = fork();
+    // if (!client->is_chunked || (client->is_chunked && client->is_first)) {
+        pipe(p);
+        client_->SetPipeRead(p[READ]);
+        client_->SetPipeWrite(p[WRITE]);
+        pid = fork();
+    // } else {
+    //     pid = 1;
+    //     p[READ] = client_->GetPipeRead();
+    //     p[WRITE] = client_->GetPipeWrite();
+    // }
     if (pid > 0) {
         struct kevent event;
         EV_SET(&event, p[WRITE], EVFILT_WRITE, EV_ADD, 0, 0, client_);

--- a/src/CGIManager/CGIMannager.cpp
+++ b/src/CGIManager/CGIMannager.cpp
@@ -73,24 +73,22 @@ void CGIManager::SendToCGI(Data* client, int kq)
     pid_t pid;
     pipe(p);
 
-    client_->SetPipeRead(p[0]);
-    client_->SetPipeWrite(p[1]);
+    client_->SetPipeRead(p[READ]);
+    client_->SetPipeWrite(p[WRITE]);
     pid = fork();
     if (pid > 0) {
-        close(p[1]);
         struct kevent event;
-
-        EV_SET(&event, p[0], EVFILT_READ, EV_EOF | EV_ADD, 0, 0, client_);
+        EV_SET(&event, p[WRITE], EVFILT_WRITE, EV_ADD, 0, 0, client_);
         kevent(kq, &event, 1, NULL, 0, NULL);
         EV_SET(&event, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, client_);
         kevent(kq, &event, 1, NULL, 0, NULL);
     }
     else if (pid == 0) {
         SetCGIEnv(client);
-        dup2(p[1], 1);
-        dup2(p[0], 0);
-        close(p[0]);
-        close(p[1]);
+        dup2(p[WRITE], STDOUT_FILENO);
+        dup2(p[READ], STDIN_FILENO);
+        close(p[READ]);
+        close(p[WRITE]);
         extern char** environ;
         char **argv = new char*[3];
         argv[0] = strdup("python3");
@@ -106,9 +104,17 @@ void CGIManager::SendToCGI(Data* client, int kq)
         #if CGI
             std::cout << "[CGI] fork() 에러" << std::endl;
         #endif
-        // wait(NULL);
     }
-    // while(1);
+}
+
+void CGIManager::WriteToCGIPipe(Data* client, int kq) {
+    struct kevent event;
+    EV_SET(&event, client->GetPipeWrite(), EVFILT_WRITE, EV_DELETE, 0, 0, client_);
+    kevent(kq, &event, 1, NULL, 0, NULL);
+    write(client->GetPipeWrite(), client_->GetReqBodyData(), client_->GetReqBodyLength());
+    close(client->GetPipeWrite());
+    EV_SET(&event, client->GetPipeRead(), EVFILT_READ, EV_EOF | EV_ADD, 0, 0, client_);
+    kevent(kq, &event, 1, NULL, 0, NULL);
 }
 
 // kqueue에서 cgi read 발생하면!
@@ -124,7 +130,6 @@ void CGIManager::GetFromCGI(Data* client, int64_t len, int kq)
     char* buf = new char[len + 1];
     read(client_->GetPipeRead(), buf, len);
     buf[len] = '\0';
-    std::cout << client->status_code_ << std::endl;
     struct kevent event;
     EV_SET(&event, client_->GetPipeRead(), EVFILT_READ, EV_EOF | EV_DELETE, 0, 0, NULL);
     kevent(kq, &event, 1, NULL, 0, NULL);

--- a/src/CGIManager/CGIMannager.cpp
+++ b/src/CGIManager/CGIMannager.cpp
@@ -108,11 +108,13 @@ void CGIManager::SendToCGI(Data* client, int kq)
 }
 
 void CGIManager::WriteToCGIPipe(Data* client, int kq) {
+    write(client->GetPipeWrite(), client_->GetReqBodyData(), client_->GetReqBodyLength());
     struct kevent event;
     EV_SET(&event, client->GetPipeWrite(), EVFILT_WRITE, EV_DELETE, 0, 0, client_);
     kevent(kq, &event, 1, NULL, 0, NULL);
-    write(client->GetPipeWrite(), client_->GetReqBodyData(), client_->GetReqBodyLength());
-    close(client->GetPipeWrite());
+    // if (client->is_chunked == false || 
+    // (client->is_chunked == true && strncmp(client_->GetReqBodyData(), "0\r\n", 3) == 0))
+        close(client->GetPipeWrite());
     EV_SET(&event, client->GetPipeRead(), EVFILT_READ, EV_EOF | EV_ADD, 0, 0, client_);
     kevent(kq, &event, 1, NULL, 0, NULL);
 }

--- a/src/ReqHandler/ReqHandler.cpp
+++ b/src/ReqHandler/ReqHandler.cpp
@@ -233,7 +233,9 @@ void ReqHandler::ParseRecv() {
     // 헤더 파싱
     idx = ParseHeaders(idx);  // buf[idx] = 마지막 헤더줄의 /r
     // entity 넣기
-    if (entity_flag_ == 1) ParseEntity(idx);
+    if (entity_flag_ == 1) {
+      ParseEntity(idx);
+    }
     ValidateReq();
   }
 

--- a/src/Server/Server.cpp
+++ b/src/Server/Server.cpp
@@ -621,6 +621,11 @@ void Server::ExecuteWriteEventFileFd(int idx) {
   }
 }
 
+void Server::ExecuteWriteEventPipeFd(int idx) {
+  Data* client = reinterpret_cast<Data*>(events_[idx].udata);
+  cgi_manager_->WriteToCGIPipe(client, kq_);
+}
+
 void Server::ExecuteWriteEventClientFd(int idx) {
   Data* client = reinterpret_cast<Data*>(events_[idx].udata);
   #if SERVER
@@ -761,8 +766,9 @@ void Server::ExecuteWriteEvent(const int& idx) {
     return;
   }
   /* CGI에게 보내줄 pipe[WRITE]에 대한 이벤트 */
-  if (event_fd == client->GetPipeRead()) {
+  if (event_fd == client->GetPipeWrite()) {
     // TODO: implement ExcuteWriteEventPipeFd();
+    ExecuteWriteEventPipeFd(idx);
     return;
   }
 }


### PR DESCRIPTION
CGIManager 에서 body data(entity)를 서버에서 pipe[write] 를 통해 cgi의 stdin으로 넣어줍니다.
write를 해야돼서, 해당 write에 대한 이벤트 발생 및 종료시키는 부분까지 추가했습니다.

CGIManager::WriteToCGIPipe(),  CGIManager::SendToCGI 에 주석으로 해놓은 if 조건문이 있습니다.
chunk data 가 들어왔을 때를 처리해주는 부분인데, CGIManager::SendToCGI() 에서 파이프 만들고 fork 해주는 부분인데, 추후에 추가하겠습니다.